### PR TITLE
Adding bin_path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ tasks:
 or
 ```YAML
 tasks:
+  - name: Install GPG key
+    gpg_import: key_id="0x3804BB82D39DC0E3"
+      bin_path: '/usr/loca/bin/gpg'
+```
+or
+```YAML
+tasks:
   - name: Install or update GPG key
     gpg_import:
       key_id: "0x3804BB82D39DC0E3"
@@ -43,6 +50,6 @@ servers      | [ keys.gnupg.net ] | list of hostnames (or `hkp://`/`hkps://` url
 tries        |   3                | number of attempts per *server*
 delay        |  0.5               | delay between retries
 gpg_timeout  | 5                  | `gpg --keyserver-options timeout=5 ...`
-
+bin_path     | /usr/bin/gpg       | Location of gpg binary
 
 [Strange behaviors](https://gist.github.com/tnt/eedaed9a6cc75130b9cb) occur when used with [insane keys](https://gist.github.com/tnt/70b116c72be11dc3cc66). But this is a gpg-problem.

--- a/gpg_import.py
+++ b/gpg_import.py
@@ -21,6 +21,12 @@ options:
     required: true
     default: null
 
+  bin_path:
+    description:
+      - "Location of GPG binary"
+    require: false
+    default: /usr/bin/gpg
+
   state:
     description:
       - Whether to import (C(present), C(latest)), or remove (C(absent)) a key. C(refreshed) is an alias for C(latest).
@@ -110,7 +116,7 @@ class GpgImport(object):
             'refresh': '%s %s --keyserver %%s --keyserver-options timeout=%%d --refresh-keys %s',
             'recv':    '%s %s --keyserver %%s --keyserver-options timeout=%%d --recv-keys %s'
         }
-        bp = self.m.get_bin_path('gpg', True)
+        bp = self.m.get_bin_path(self.bin_path, True)
         check_mode = '--dry-run' if self.m.check_mode else ''
         for c,l in self.commands.items():
             self.commands[c] = l % (bp, check_mode, self.key_id)
@@ -148,7 +154,8 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
             key_id=dict(required=True, type='str'),
-            servers=dict(default=['keys.gnupg.org'], type='list'),
+            servers=dict(default=['keys.gnupg.net'], type='list'),
+            bin_path=dict(default='/usr/bin/gpg', type='str'),
             tries=dict(default=3, type='int'),
             delay=dict(default=0.5),
             state=dict(default='present', choices=['latest', 'refreshed', 'absent', 'present']),


### PR DESCRIPTION
Without this option, it fails with:

```
FAILED! => {"changed": false, "failed": true, "msg": "Failed to find required executable gpg"}
```

Defaults to `/usr/bin/gpg` for "normal" folks ;)
