### PR TITLE
Feature import private key from file

### DIFF
--- a/gpg_import.py
+++ b/gpg_import.py
@@ -94,6 +94,9 @@ EXAMPLES = '''
 
 - name: import a file-based public key
   gpg_import: key_type=public state=present key_file=/etc/customer-key/customer.pubkey
+
+- name: import a file-based private key
+  gpg_import: key_type=private state=present key_file=/etc/customer-key/customer.privatekey
 '''
 
 class SafeDict(dict):


### PR DESCRIPTION
Following with #7 I would like to import private key files.

- Small refactor on the commands to reuse one for this feature.
- Extended the key_present block to check if the private key is already imported.
- Added `check-private` command.

--- 

Comments

if you run `gpg --import key.private` with a non-existent key in the keyring, the first time you will get exit code 0 but the second time you will get 2. For this reason I had to extend the key_present block.