### PR TITLE
fix key_present when using key_id

### DIFF
--- a/gpg_import.py
+++ b/gpg_import.py
@@ -128,7 +128,10 @@ class GpgImport(object):
 
     def _execute_task(self):
         key_present = False
-        if self.key_type == 'public':
+        if self.key_id:
+            res = self._execute_command('check')
+            key_present = res['rc'] == 0
+        elif self.key_type == 'public':
             filekey = self._get_key_from_file()
             if filekey:
                 # rerun the original setup with this key in the commands
@@ -144,9 +147,6 @@ class GpgImport(object):
                 res = self._execute_command('check-private')
                 self._debug('checkprivate: %s' % (str(res)))
                 key_present = res['rc'] == 0
-        else:
-            res = self._execute_command('check')
-            key_present = res['rc'] == 0
 
         if key_present and self.state == 'absent':
             res = self._execute_command('delete')


### PR DESCRIPTION
I noticed that the module always reports changed when importing my key from a public server. Since `key_type` is `private` by default, it never entered the last `else:`

I haven't tested this with `key_file`, but as far as I can see `key_id` and `key_file` are exclusive