### PR TITLE
Properly check the keys when no file is specified

### DIFF
--- a/gpg_import.py
+++ b/gpg_import.py
@@ -128,22 +128,23 @@ class GpgImport(object):
 
     def _execute_task(self):
         key_present = False
-        if self.key_type == 'public':
-            filekey = self._get_key_from_file()
-            if filekey:
-                # rerun the original setup with this key in the commands
-                self._setup_creds(filekey)
-                res = self._execute_command('check-public')
-                self._debug('checkpublic: %s' % (str(res)))
-                key_present = res['rc'] == 0
-        elif self.key_type == 'private':
-            filekey = self._get_key_from_file()
-            if filekey:
-                # rerun the original setup with this key in the commands
-                self._setup_creds(filekey)
-                res = self._execute_command('check-private')
-                self._debug('checkprivate: %s' % (str(res)))
-                key_present = res['rc'] == 0
+        if self.key_file:
+            if self.key_type == 'public':
+                filekey = self._get_key_from_file()
+                if filekey:
+                    # rerun the original setup with this key in the commands
+                    self._setup_creds(filekey)
+                    res = self._execute_command('check-public')
+                    self._debug('checkpublic: %s' % (str(res)))
+                    key_present = res['rc'] == 0
+            elif self.key_type == 'private':
+                filekey = self._get_key_from_file()
+                if filekey:
+                    # rerun the original setup with this key in the commands
+                    self._setup_creds(filekey)
+                    res = self._execute_command('check-private')
+                    self._debug('checkprivate: %s' % (str(res)))
+                    key_present = res['rc'] == 0
         else:
             res = self._execute_command('check')
             key_present = res['rc'] == 0


### PR DESCRIPTION
Due to how the defaults are setup this else clause could previously never be reached (`self.key_type` is always either public or private) so the check command would not be run under any circumstances. The check command seems intended for when keys are imported not from a file (so from a keyserver) so I changed the condition to be that.